### PR TITLE
Set ready to true if the redis client is already connected.

### DIFF
--- a/_src/lib/sessionhandler.coffee
+++ b/_src/lib/sessionhandler.coffee
@@ -22,7 +22,7 @@ module.exports = class SessionHandler
 		else
 			@debug = false
 
-		@ready = false
+		@ready = @redis.connected
 		@redis.on "connect", => @ready = true
 		@redis.on "disconnect", => @ready = false
 


### PR DESCRIPTION
Providing an existing redis client is supported by the library, however providing a client which is already `connected` means the library will never enter the `ready` state. This state should default to the connected status of the redis client.